### PR TITLE
Reward calculator

### DIFF
--- a/AmoebaPlayGround/Amoeba.py
+++ b/AmoebaPlayGround/Amoeba.py
@@ -1,7 +1,14 @@
 import copy
+from typing import List
 
 from AmoebaPlayGround.GameBoard import AmoebaBoard, Symbol, Player
 
+
+class Move:
+    def __init__(self, board_state, step, player: Player):
+        self.board_state = board_state
+        self.step = step
+        self.player = player
 
 class AmoebaGame:
     def __init__(self, map_size, view=None):
@@ -24,7 +31,7 @@ class AmoebaGame:
         self.history = []
         self.winner = None
         self.num_steps = 1
-        if self.view != None:
+        if self.view is not None:
             self.view.display_game_state(self.map)
 
     def step(self, action):
@@ -35,8 +42,24 @@ class AmoebaGame:
         self.history.append(action)
         self.num_steps += 1
         self.next_player = self.next_player.get_other_player()
-        if self.view != None:
+        if self.view is not None:
             self.view.display_game_state(self.map)
+
+    def get_last_moves(self, number_of_steps: int) -> List[Move]:
+        moves = []
+        map = copy.deepcopy(self.map)
+        if len(self.history) < number_of_steps:
+            number_of_steps = len(self.history)
+
+        player = self.next_player.get_other_player()
+        for index in range(number_of_steps):
+            step = self.history[len(self.history) - index - 1]
+            map.set(step, Symbol.EMPTY)
+            map.perspective = player
+            move = Move(map.get_numeric_representation(), step, player)
+            moves.append(move)
+            player = player.get_other_player()
+        return moves
 
     def has_game_ended(self):
         last_action = self.history[-1]
@@ -86,8 +109,8 @@ class AmoebaGame:
                 return True
         return False
 
-
     def get_map_for_next_player(self):
         map_to_return = copy.copy(self.map)
         map_to_return.perspective = self.next_player
         return map_to_return
+

--- a/AmoebaPlayGround/AmoebaTrainer.py
+++ b/AmoebaPlayGround/AmoebaTrainer.py
@@ -1,10 +1,12 @@
 from AmoebaPlayGround.Amoeba import AmoebaGame, Player
+from AmoebaPlayGround.RewardCalculator import PolicyGradients
 
 
 class AmoebaTrainer:
-    def __init__(self, x_agent, o_agent):
+    def __init__(self, x_agent, o_agent, reward_calculator=PolicyGradients()):
         self.x_agent = x_agent
         self.o_agent = o_agent
+        self.reward_calculator = reward_calculator
 
     def init_games(self, batch_size, map_size, view):
         games = []
@@ -15,6 +17,9 @@ class AmoebaTrainer:
     def train(self, batch_size=1, map_size=(8, 8), view=None):
         games = self.init_games(batch_size, map_size, view)
         games = self.play_all_games(games)
+        training_samples = self.reward_calculator.get_training_data(games)
+        for training_sample in training_samples:
+            print(training_sample)
         # TODO training
         # 1. play_all_games is already written but there is no neural network agent implementation yet. Ideas for it:
         #    - outputs size same as input size each output feature is the probability of making a move in that cell(non empty cells are ignored)
@@ -24,9 +29,7 @@ class AmoebaTrainer:
         #      new tactics
         #    - this algorithm can be referred to as monte carlo tree search because putting monte carlo in an algorithm has the same effect as
         #      painting flames on a car
-        # 2. rewards could be calculated in diffent ways, policy gradients q values, q values with heuristics etc, there should be a dedicated
-        # interface that allows rapidly changing these. This interface is given some games, and returns a list of state, action, reward comobs.
-        # It does not have to return this comobo for every move in the game. It also does not matter which game a combo belonged to (i hope)
+            # 2. DONE, could still be extended with different reward calculation methods in the future, like heuristics
         # 3. these combos, lets call them training points can be fed into the network for supervised training. Questions:
         #    - does it need more than one epoch?
         #    - should only the latest batch of games be fed, or earlier ones too?
@@ -48,7 +51,7 @@ class AmoebaTrainer:
             active_games = [game for game in active_games if not game in finished_games]
         return finished_games
 
-    def get_maps_of_games(selfl, games):
+    def get_maps_of_games(self, games):
         maps = []
         for game in games:
             maps.append(game.get_map_for_next_player())

--- a/AmoebaPlayGround/AmoebaView.py
+++ b/AmoebaPlayGround/AmoebaView.py
@@ -39,7 +39,6 @@ class ConsoleView(AmoebaView):
             print('Game ended! It is a draw')
 
 
-
 class BoardCell:
     def __init__(self, window, row, column, symbol_size):
         self.symbol = Symbol.EMPTY

--- a/AmoebaPlayGround/GameBoard.py
+++ b/AmoebaPlayGround/GameBoard.py
@@ -82,6 +82,8 @@ class AmoebaBoard:
 
     def get_numeric_representation(self):
         if self.perspective == Player.X:
-            return np.array(list(map(lambda cell: cell.value, self.cells)))
+            mapper = np.vectorize(lambda cell: cell.value)
+            return mapper(self.cells)
         else:
-            return np.array(list(map(lambda cell: cell.value * (-1), self.cells)))
+            mapper = np.vectorize(lambda cell: cell.value * (-1))
+            return mapper(self.cells)

--- a/AmoebaPlayGround/RewardCalculator.py
+++ b/AmoebaPlayGround/RewardCalculator.py
@@ -1,0 +1,80 @@
+import math
+from typing import List
+
+from AmoebaPlayGround.Amoeba import AmoebaGame, Move
+from AmoebaPlayGround.GameBoard import Player
+
+
+class RewardCalculator():
+    def get_training_data(self, games: List[AmoebaGame]):
+        pass
+
+
+class TrainingSample:
+    def __init__(self, move: Move, reward: float):
+        self.board_state = move.board_state
+        self.step = move.step
+        self.reward = reward
+
+    def __str__(self):
+        return str(self.step) + " " + str(self.reward)
+
+
+class PolicyGradients(RewardCalculator):
+    def __init__(self, discount_factor=0.8, reward_for_win=1, reward_for_loss=-1,
+                 reward_for_tie=-0.5, reward_cutoff_threshold=0.05, teach_with_draws=True):
+        self.discount_factor = discount_factor
+        self.reward_for_win = reward_for_win
+        self.reward_for_loss = reward_for_loss
+        self.reward_for_tie = reward_for_tie
+        self.reward_cutoff_threshold = reward_cutoff_threshold
+        self.teach_with_draws = teach_with_draws
+
+    def get_training_data(self, games: List[AmoebaGame]) -> List[TrainingSample]:
+        training_samples = []
+        for game in games:
+            training_samples.extend(self._get_training_samples_from_game(game))
+        return training_samples
+
+    def _get_training_samples_from_game(self, game: AmoebaGame) -> List[TrainingSample]:
+        steps_needed = self._get_num_of_steps_needed()
+        moves = game.get_last_moves(steps_needed)
+        winner = game.winner
+        if self.teach_with_draws and winner == Player.NOBODY:
+            return self._get_training_samples_from_draw(self, moves)
+        elif winner != Player.NOBODY:
+            winner_moves = filter(lambda move: move.player == winner, moves)
+            winner_samples = self._get_training_samples(winner_moves, self.reward_for_win)
+
+            loser_moves = filter(lambda move: move.player != winner, moves)
+            loser_samples = self._get_training_samples(loser_moves, self.reward_for_loss)
+
+            winner_samples.extend(loser_samples)
+            return winner_samples
+        return []
+
+    def _get_training_samples(self, moves, reward):
+        discounted_reward = reward
+        training_samples = []
+        for move in moves:
+            sample = TrainingSample(move, discounted_reward)
+            discounted_reward = discounted_reward * self.discount_factor
+            training_samples.append(sample)
+        return training_samples
+
+    def _get_training_samples_from_draw(self, moves, reward):
+        discounted_reward = reward
+        training_samples = []
+        for index, move in enumerate(moves):
+            sample = TrainingSample(move, discounted_reward)
+            if index % 2 == 1:
+                discounted_reward = discounted_reward * self.discount_factor
+            training_samples.append(sample)
+        return training_samples
+
+    def _get_num_of_steps_needed(self):
+        # if the reward is close to 0 it is not worth it to add to training, determine how many steps
+        # it takes for it to fade
+        steps_needed = math.floor(math.log(self.reward_cutoff_threshold, self.discount_factor))
+        # multiplied by two because since there are two players it takes rewards get decreased every two turns
+        return int(steps_needed * 2)


### PR DESCRIPTION
Added RewardCalculator that recieves the games of an episode and creates
trainings samples from it. Moves further back from the winning move constitute less reward, when reward approaches zero it gets cut off.
- rewards for wins losses an draws are configurable
- whether draws are included in training is configurable
- the reward cutoff is calculated based upon the win reward, meaning if loss reward is less (in absoute value) than win reward, loss rewards under the threshold will be generated.
- cutoff threshold is configurable