### PR TITLE
Multi teacher training and more

### DIFF
--- a/AmoebaPlayGround/Amoeba.py
+++ b/AmoebaPlayGround/Amoeba.py
@@ -4,6 +4,7 @@ from typing import List
 from AmoebaPlayGround.GameBoard import AmoebaBoard, Symbol, Player
 
 win_sequence_length = 5
+map_size = (8, 8)
 
 class Move:
     def __init__(self, board_state, step, player: Player):
@@ -12,7 +13,7 @@ class Move:
         self.player = player
 
 class AmoebaGame:
-    def __init__(self, map_size, view=None):
+    def __init__(self, view=None):
         self.view = view
         if len(map_size) != 2:
             raise Exception('Map must be two dimensional but found shape %s' % (map_size))

--- a/AmoebaPlayGround/AmoebaAgent.py
+++ b/AmoebaPlayGround/AmoebaAgent.py
@@ -18,6 +18,9 @@ class AmoebaAgent:
     def save(self, model_name):
         pass
 
+    def get_name(self):
+        return 'Default Name'
+
 
 class ConsoleAgent(AmoebaAgent):
     def get_step(self, game_boards):
@@ -65,3 +68,6 @@ class RandomAgent(AmoebaAgent):
                 if game_board.is_within_bounds((row, column)) and not game_board.is_cell_empty((row, column)):
                     return True
         return False
+
+    def get_name(self):
+        return 'RandomAgent'

--- a/AmoebaPlayGround/AmoebaTrainer.py
+++ b/AmoebaPlayGround/AmoebaTrainer.py
@@ -6,37 +6,37 @@ from AmoebaPlayGround.RewardCalculator import PolicyGradients
 
 
 class AmoebaTrainer:
-    def __init__(self, learning_agent, teaching_agent=None, reward_calculator=PolicyGradients()):
+    def __init__(self, learning_agent, teaching_agents, reward_calculator=PolicyGradients(), self_play=True):
         self.learning_agent: AmoebaAgent = learning_agent
-        if teaching_agent is None:
-            self.self_play = True
-            self.teaching_agent = learning_agent
-        else:
-            self.self_play = False
-            self.teaching_agent = teaching_agent
         self.reward_calculator = reward_calculator
+        self.teaching_agents = teaching_agents
+        self.self_play = self_play
+        if self.self_play:
+            # TODO have a factory method so neuralagent doesn't have to be hardcoded
+            self.learning_agent_with_old_state = NeuralNetwork(self.learning_agent.board_size)
+            self.teaching_agents.append(self.learning_agent_with_old_state)
 
     def train(self, batch_size=1, map_size=(8, 8), view=None, num_episodes=1):
         evaluator = EloEvaluator(map_size)
-        evaluator.set_reference_agent(self.teaching_agent)
+        evaluator.set_reference_agent(self.learning_agent_with_old_state)
         for episode_index in range(num_episodes):
             print('\nEpisode %d:' % episode_index)
+            played_games = []
+            for teacher_index, teaching_agent in enumerate(self.teaching_agents):
+                game_group = GameGroup(batch_size, map_size, self.learning_agent, teaching_agent,
+                                       view, log_progress=True)  # TODO swap x and o agents
+                print('Playing games against agent ' + str(teacher_index))
+                played_games.extend(game_group.play_all_games())
+            training_samples = self.reward_calculator.get_training_data(played_games)
             if self.self_play:
-                self.teaching_agent.save('reference_agent')
-                self.learning_agent = NeuralNetwork(model_name='reference_agent')
-                # TODO have a factory method so neuralagent doesn't have to be hardcoded
-            game_group = GameGroup(batch_size, map_size, self.learning_agent, self.teaching_agent,
-                                   view, log_progress=True)  # TODO swap x and o agents
-            print('Playing games:')
-            games = game_group.play_all_games()
-            training_samples = self.reward_calculator.get_training_data(games)
+                self.learning_agent.copy_weights_into(self.learning_agent_with_old_state)
             print('Training agent:')
             self.learning_agent.train(training_samples)
             print('Evaluating agent:')
             agent_rating = evaluator.evaluate_agent(self.learning_agent)
             print('Learning agent rating: %f' % agent_rating)
             if self.self_play:
-                evaluator.set_reference_agent(self.learning_agent, agent_rating)
+                evaluator.set_reference_agent(self.learning_agent_with_old_state, agent_rating)
 
 
             # 1. There is a basic neural network implementation that is conv -> dense. Further ideas:

--- a/AmoebaPlayGround/AmoebaTrainer.py
+++ b/AmoebaPlayGround/AmoebaTrainer.py
@@ -13,14 +13,13 @@ class AmoebaTrainer:
         self.self_play = self_play
         if self.self_play:
             # TODO have a factory method so neuralagent doesn't have to be hardcoded
-            self.learning_agent_with_old_state = NeuralAgent(self.learning_agent.board_size)
+            self.learning_agent_with_old_state = NeuralAgent(model_type=self.learning_agent.model_type)
             self.teaching_agents.append(self.learning_agent_with_old_state)
 
-    def train(self, batch_size=1, map_size=(8, 8), view=None, num_episodes=1):
+    def train(self, batch_size=1, view=None, num_episodes=1):
         self.batch_size = batch_size
-        self.map_size = map_size
         self.view = view
-        evaluator = EloEvaluator(map_size)
+        evaluator = EloEvaluator()
         evaluator.set_reference_agent(self.learning_agent_with_old_state)
         for episode_index in range(num_episodes):
             print('\nEpisode %d:' % episode_index)
@@ -52,9 +51,9 @@ class AmoebaTrainer:
             #    the winrate of the agent and the rating of the previous version
 
     def play_games_between_agents(self, agent_one, agent_two):
-        game_group_1 = GameGroup(int(self.batch_size / 2), self.map_size, agent_one, agent_two,
+        game_group_1 = GameGroup(int(self.batch_size / 2), agent_one, agent_two,
                                  self.view, log_progress=True)
-        game_group_2 = GameGroup(int(self.batch_size / 2), self.map_size, agent_two, agent_one,
+        game_group_2 = GameGroup(int(self.batch_size / 2), agent_two, agent_one,
                                  self.view, log_progress=True)
 
         played_games = game_group_1.play_all_games()

--- a/AmoebaPlayGround/AmoebaTrainer.py
+++ b/AmoebaPlayGround/AmoebaTrainer.py
@@ -1,7 +1,7 @@
 from AmoebaPlayGround import AmoebaAgent
 from AmoebaPlayGround.Evaluator import EloEvaluator
 from AmoebaPlayGround.GameGroup import GameGroup
-from AmoebaPlayGround.NeuralAgent import NeuralNetwork
+from AmoebaPlayGround.NeuralAgent import NeuralAgent
 from AmoebaPlayGround.RewardCalculator import PolicyGradients
 
 
@@ -13,7 +13,7 @@ class AmoebaTrainer:
         self.self_play = self_play
         if self.self_play:
             # TODO have a factory method so neuralagent doesn't have to be hardcoded
-            self.learning_agent_with_old_state = NeuralNetwork(self.learning_agent.board_size)
+            self.learning_agent_with_old_state = NeuralAgent(self.learning_agent.board_size)
             self.teaching_agents.append(self.learning_agent_with_old_state)
 
     def train(self, batch_size=1, map_size=(8, 8), view=None, num_episodes=1):

--- a/AmoebaPlayGround/Evaluator.py
+++ b/AmoebaPlayGround/Evaluator.py
@@ -18,11 +18,10 @@ class Evaluator:
 
 
 class EloEvaluator(Evaluator):
-    def __init__(self, map_size, evaluation_match_count=100):
+    def __init__(self, evaluation_match_count=100):
         self.reference_agent = None
         self.reference_agent_rating = None
         self.evaluation_match_count = evaluation_match_count
-        self.map_size = map_size
 
     def evaluate_agent(self, agent: AmoebaAgent):
         self.evaluate_against_fixed_references(agent)
@@ -44,9 +43,9 @@ class EloEvaluator(Evaluator):
 
     def calculate_expected_score(self, agent_to_evaluate, reference_agent, evaluation_match_count):
         game_group_size = int(evaluation_match_count / 2)
-        game_group_reference_starts = GameGroup(game_group_size, self.map_size,
+        game_group_reference_starts = GameGroup(game_group_size,
                                                 reference_agent, agent_to_evaluate)
-        game_group_agent_started = GameGroup(game_group_size, self.map_size,
+        game_group_agent_started = GameGroup(game_group_size,
                                              agent_to_evaluate, reference_agent)
         finished_games_reference_started = game_group_reference_starts.play_all_games()
         finished_games_agent_started = game_group_agent_started.play_all_games()

--- a/AmoebaPlayGround/GameGroup.py
+++ b/AmoebaPlayGround/GameGroup.py
@@ -4,13 +4,13 @@ from AmoebaPlayGround.Amoeba import AmoebaGame, Player
 
 
 class GameGroup:
-    def __init__(self, batch_size, map_size, x_agent, o_agent, view=None, log_progress=False):
+    def __init__(self, batch_size, x_agent, o_agent, view=None, log_progress=False):
         self.x_agent = x_agent
         self.o_agent = o_agent
         self.log_progress = log_progress
         self.games = []
         for index in range(batch_size):
-            self.games.append(AmoebaGame(map_size, view))
+            self.games.append(AmoebaGame(view))
 
     def play_all_games(self):
         finished_games = []

--- a/AmoebaPlayGround/NeuralAgent.py
+++ b/AmoebaPlayGround/NeuralAgent.py
@@ -140,3 +140,16 @@ class NeuralNetwork(AmoebaAgent):
             with self.session.as_default():
                 self.model.fit(x=input, y=np.array(output), sample_weight=np.array(weights), epochs=15, shuffle=True,
                                verbose=2, batch_size=32)
+
+    def get_weights(self):
+        with self.graph.as_default():
+            with self.session.as_default():
+                return self.model.get_weights()
+
+    def set_weights(self, weights):
+        with self.graph.as_default():
+            with self.session.as_default():
+                self.model.set_weights(weights)
+
+    def copy_weights_into(self, agent_to_copy_into):
+        agent_to_copy_into.set_weights(self.get_weights())

--- a/AmoebaPlayGround/NeuralAgent.py
+++ b/AmoebaPlayGround/NeuralAgent.py
@@ -153,3 +153,6 @@ class NeuralNetwork(AmoebaAgent):
 
     def copy_weights_into(self, agent_to_copy_into):
         agent_to_copy_into.set_weights(self.get_weights())
+
+    def get_name(self):
+        return 'NeuralAgent'

--- a/main.py
+++ b/main.py
@@ -1,7 +1,7 @@
 import AmoebaPlayGround.Amoeba as Amoeba
 from AmoebaPlayGround.AmoebaAgent import RandomAgent
 from AmoebaPlayGround.AmoebaTrainer import AmoebaTrainer
-from AmoebaPlayGround.NeuralAgent import NeuralNetwork
+from AmoebaPlayGround.NeuralAgent import NeuralAgent, ResNetLike
 # graphicalView = GraphicalView((10, 10))
 # game_board = np.array([[0,0,0,0],[0,1,1,1],[-1,-1,-1,0],[0,1,-1,0]])
 # graphicalView.display_game_state(game_board)
@@ -13,7 +13,7 @@ from AmoebaPlayGround.RewardCalculator import PolicyGradients
 map_size = (8, 8)
 Amoeba.win_sequence_length = 5
 
-learning_agent = NeuralNetwork(map_size)
+learning_agent = NeuralAgent(map_size, model_creator=ResNetLike())
 random_agent = RandomAgent()
 trainer = AmoebaTrainer(learning_agent, teaching_agents=[random_agent], self_play=True,
                         reward_calculator=PolicyGradients(teach_with_losses=False))

--- a/main.py
+++ b/main.py
@@ -1,7 +1,7 @@
 import AmoebaPlayGround.Amoeba as Amoeba
 from AmoebaPlayGround.AmoebaAgent import RandomAgent
 from AmoebaPlayGround.AmoebaTrainer import AmoebaTrainer
-from AmoebaPlayGround.NeuralAgent import NeuralAgent, ResNetLike
+from AmoebaPlayGround.NeuralAgent import NeuralAgent, ShallowNetwork
 # graphicalView = GraphicalView((10, 10))
 # game_board = np.array([[0,0,0,0],[0,1,1,1],[-1,-1,-1,0],[0,1,-1,0]])
 # graphicalView.display_game_state(game_board)
@@ -10,12 +10,12 @@ from AmoebaPlayGround.NeuralAgent import NeuralAgent, ResNetLike
 # view = ConsoleView()
 from AmoebaPlayGround.RewardCalculator import PolicyGradients
 
-map_size = (8, 8)
+Amoeba.map_size = (8, 8)
 Amoeba.win_sequence_length = 5
 
-learning_agent = NeuralAgent(map_size, model_creator=ResNetLike())
+learning_agent = NeuralAgent(model_type=ShallowNetwork())
 random_agent = RandomAgent()
 trainer = AmoebaTrainer(learning_agent, teaching_agents=[random_agent], self_play=True,
                         reward_calculator=PolicyGradients(teach_with_losses=False))
 
-trainer.train(batch_size=500, map_size=map_size, num_episodes=5)
+trainer.train(batch_size=500, num_episodes=5)

--- a/main.py
+++ b/main.py
@@ -13,44 +13,9 @@ from AmoebaPlayGround.RewardCalculator import PolicyGradients
 map_size = (8, 8)
 Amoeba.win_sequence_length = 5
 
-agent = NeuralNetwork(map_size)
-counter_agent = NeuralNetwork(map_size)
+learning_agent = NeuralNetwork(map_size)
 random_agent = RandomAgent()
+trainer = AmoebaTrainer(learning_agent, teaching_agents=[random_agent], self_play=True,
+                        reward_calculator=PolicyGradients(teach_with_losses=False))
 
-trainer_ai_random = AmoebaTrainer(agent, random_agent)
-trainer_aic_random = AmoebaTrainer(counter_agent, random_agent)
-trainer_ai_aic = AmoebaTrainer(agent, counter_agent,
-                               reward_calculator=PolicyGradients(teach_with_losses=False))
-trainer_aic_ai = AmoebaTrainer(counter_agent, agent,
-                               reward_calculator=PolicyGradients(teach_with_losses=False))
-
-
-batch_againt_random = 500
-batch_against_ai = 1000
-save_step = 1
-
-
-def non_episodic_train(trainer, batch_size):
-    trainer.train(batch_size, map_size=map_size, view=None,
-                  num_episodes=1)
-
-
-for i in range(100):
-    print('\nCycle {}'.format(i))
-
-    # These two steps could be parallelised.
-    print('\nTraining agent against random agent.')
-    non_episodic_train(trainer_ai_random, batch_againt_random)
-
-    print('\nTraining counter agent against random.\nCycle {}'.format(i))
-    non_episodic_train(trainer_aic_random, batch_againt_random)
-
-    print('\nTraining agent against counter agent.\nCycle {}'.format(i))
-    non_episodic_train(trainer_ai_aic, batch_against_ai)
-
-    print('\nTraining counter agent against agent.\nCycle {}'.format(i))
-    non_episodic_train(trainer_aic_ai, batch_against_ai)
-
-    if i % save_step == 0:
-        agent.save('model{}'.format(i))
-        counter_agent.save('model_c{}'.format(i))
+trainer.train(batch_size=500, map_size=map_size, num_episodes=5)


### PR DESCRIPTION
Changelog:
- playing against multiple teaching agents is now supported in AmobeaTrainer, this includes the learning agent itself if self_play flag is set
- self play now does not require saving and reloading models
- agents now have names that are displayed during training to identify them
- during training now the teacher and learning agent both play as x and o
- minor refactoring on amobeatrainer
- neuralnetwork renamed to neuralagent
- neuralagent now supports model type configuration, current options are ShallowNetwork(previously used) and ResNetLike
- ResNetLike model type added, which is a downsized version of a resnet network, though it is still very resource intensive to run
- map_size is now a global parameter not needed to be passed around 
- board_size in neuralagent renamed to map_size for naming consistency

